### PR TITLE
Fix eslint and stylus dependency issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/wesbos/Learn-Redux",
   "dependencies": {
     "babel-core": "^6.5.2",
-    "babel-eslint": "^5.0.0",
+    "babel-eslint": "^6.1.2",
     "babel-loader": "^6.2.3",
     "babel-plugin-react-transform": "^2.0.0",
     "babel-plugin-transform-object-rest-spread": "^6.5.0",
@@ -27,7 +27,7 @@
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-react": "^6.5.0",
     "css-loader": "^0.23.1",
-    "eslint": "^2.2.0",
+    "eslint": "^3.4.0",
     "eslint-plugin-babel": "^3.1.0",
     "eslint-plugin-react": "^4.1.0",
     "express": "^4.13.4",
@@ -44,7 +44,8 @@
     "redux": "^3.3.1",
     "rimraf": "^2.5.2",
     "style-loader": "^0.13.0",
-    "stylus-loader": "^1.5.1",
+    "stylus": "^0.54.5",
+    "stylus-loader": "^2.3.1",
     "webpack": "^1.12.14",
     "webpack-dev-middleware": "^1.5.1",
     "webpack-hot-middleware": "^2.7.1"


### PR DESCRIPTION
1. Updated 'babel-eslint' and 'eslint' to solve this issue:
   https://github.com/wesbos/Learn-Redux/issues/5
2. Updated 'stylus-loader' and added 'stylus' to solve this issue:
   https://github.com/wesbos/Learn-Redux/issues/2
